### PR TITLE
Fix indentation bug in docker install playbook

### DIFF
--- a/Ansible/Docker/docker-install-via-script.yaml
+++ b/Ansible/Docker/docker-install-via-script.yaml
@@ -16,6 +16,6 @@
     become: true
     # become_user: venu
     become_method: sudo
-    - name: printing message for user
+  - name: printing message for user
     debug:
       msg: "{{author_msg.msg1}}"


### PR DESCRIPTION
## Summary
- correct indentation in `docker-install-via-script.yaml`
- ensure file ends with newline

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68805c0ee5e08323962b8600b69630e1